### PR TITLE
Start server by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A smart command-line tool that automatically detects and runs development server
 - ⚙️ **Flexible Configuration** - Override defaults with local or global config files
 - 🎯 **Smart Detection** - Reads `package.json` scripts and identifies project types
 - 🌍 **Multi-Project Support** - Manage all your projects from a single global config
+- 🏷️ **Named Projects** - Start servers by project name from anywhere
 - 🔧 **Environment Variables** - Set environment variables per project
 - 📦 **Lightweight** - Single Ruby script, no dependencies
 
@@ -113,11 +114,19 @@ If you see the help message, you're all set! 🎉
 
 ### Basic Usage
 
-Simply navigate to your project directory and run:
+#### Option 1: Run from Project Directory
+Navigate to your project directory and run:
 
 ```bash
 cd ~/projects/my-rails-app
 dev-serve
+```
+
+#### Option 2: Run by Project Name (NEW!)
+Start any project from anywhere using its name:
+
+```bash
+dev-serve my-app-backend
 ```
 
 That's it! `dev-serve` will:
@@ -139,11 +148,16 @@ This creates a `.dev-serve.yml` file in your current directory with smart defaul
 ### Command Line Options
 
 ```bash
-dev-serve [options]
+dev-serve [project-name] [options]
 
 Options:
   --init          Initialize config file in current directory
   -h, --help      Show help message
+
+Examples:
+  dev-serve                    # Run server in current directory
+  dev-serve my-app-backend     # Run server for named project
+  dev-serve --init             # Initialize config file
 ```
 
 ## ⚙️ Configuration
@@ -188,6 +202,7 @@ Manage multiple projects from a single file at `~/.config/dev-serve/config.yml`:
 projects:
   # Rails backend
   - path: ~/projects/my-app-backend
+    name: my-app-backend
     command: bin/rails server
     env:
       RAILS_ENV: development
@@ -195,16 +210,19 @@ projects:
 
   # Next.js frontend
   - path: ~/projects/my-app-frontend
+    name: my-app-frontend
     command: npm run dev
     env:
       NEXT_PUBLIC_API_URL: http://localhost:3000
 
   # React Native admin panel
   - path: ~/projects/my-app-admin
+    name: my-app-admin
     command: pnpm dev
 
   # Express.js middleware
   - path: ~/projects/my-app-middleware
+    name: my-app-middleware
     command: npm run start:dev
     env:
       NODE_ENV: development
@@ -213,10 +231,45 @@ projects:
 
 **Important**: Use absolute paths in the global config. The `~` character will be expanded automatically.
 
+### Named Projects
+
+With named projects, you can start any development server from anywhere by using the project name:
+
+```bash
+# From any directory, start your Rails backend
+dev-serve my-app-backend
+
+# Start your Next.js frontend
+dev-serve my-app-frontend
+
+# Start your admin panel
+dev-serve my-app-admin
+```
+
+The script will:
+1. Look up the project in your global config by name
+2. Change to the project directory
+3. Run the configured command
+
+If a project name is not found, the script will show you all available projects:
+
+```bash
+$ dev-serve unknown-project
+❌ Project 'unknown-project' not found in global config
+Available projects:
+  - my-app-backend (~/projects/my-app-backend)
+  - my-app-frontend (~/projects/my-app-frontend)
+  - my-app-admin (~/projects/my-app-admin)
+
+Check your global config at ~/.config/dev-serve/config.yml
+```
+
 ### Configuration Options
 
 | Option | Description | Example |
 |--------|-------------|---------|
+| `path` | Project directory path | `~/projects/my-app` |
+| `name` | Project name for running by name | `my-app-backend` |
 | `command` | Command to run the dev server | `bin/rails server`, `npm run dev` |
 | `env` | Environment variables (optional) | `RAILS_ENV: development` |
 
@@ -417,7 +470,7 @@ Found a bug? Have a feature request?
 ## 🎯 Roadmap
 
 - [ ] Support for `.env` file loading
-- [ ] Project aliases (run by name instead of path)
+- [x] Project aliases (run by name instead of path) ✅
 - [ ] Multi-command support (run multiple servers)
 - [ ] Interactive project selector
 - [ ] Health check and auto-restart

--- a/dev-serve
+++ b/dev-serve
@@ -13,6 +13,7 @@ class DevServe
   def initialize
     @current_dir = Dir.pwd
     @options = {}
+    @project_name = nil
   end
 
   def run(args)
@@ -33,6 +34,9 @@ class DevServe
     end
 
     puts "🚀 Starting development server..."
+    if @project_name
+      puts "📦 Project: #{@project_name}"
+    end
     puts "📁 Directory: #{@current_dir}"
     puts "⚡ Command: #{command}"
     puts "\n#{'-' * 50}\n\n"
@@ -44,7 +48,7 @@ class DevServe
 
   def parse_options(args)
     OptionParser.new do |opts|
-      opts.banner = "Usage: dev-serve [options]"
+      opts.banner = "Usage: dev-serve [project-name] [options]"
 
       opts.on("--init", "Initialize config file in current directory") do
         @options[:init] = true
@@ -52,9 +56,18 @@ class DevServe
 
       opts.on("-h", "--help", "Show this help message") do
         puts opts
+        puts "\nExamples:"
+        puts "  dev-serve                    # Run server in current directory"
+        puts "  dev-serve my-app-backend     # Run server for named project"
+        puts "  dev-serve --init             # Initialize config file"
         exit
       end
     end.parse!(args)
+    
+    # Check if first argument is a project name (not an option)
+    if args.any? && !args.first.start_with?('-')
+      @project_name = args.first
+    end
   end
 
   def init_config
@@ -112,6 +125,11 @@ class DevServe
   end
 
   def load_config
+    # If project name is provided, look it up in global config
+    if @project_name
+      return find_project_by_name(@project_name)
+    end
+
     # Check for local config first
     local_config_path = File.join(@current_dir, CONFIG_FILENAME)
     if File.exist?(local_config_path)
@@ -139,6 +157,40 @@ class DevServe
     end
 
     nil
+  end
+
+  def find_project_by_name(project_name)
+    return nil unless File.exist?(GLOBAL_CONFIG_PATH)
+
+    global_config = YAML.load_file(GLOBAL_CONFIG_PATH)
+    return nil unless global_config && global_config['projects']
+
+    # Find project by name
+    project = global_config['projects'].find { |p| p['name'] == project_name }
+    
+    if project
+      # Change to the project directory
+      project_path = File.expand_path(project['path'])
+      unless Dir.exist?(project_path)
+        puts "❌ Project directory not found: #{project_path}"
+        puts "Please check your global config at #{GLOBAL_CONFIG_PATH}"
+        exit 1
+      end
+      
+      # Update current directory to the project directory
+      @current_dir = project_path
+      Dir.chdir(project_path)
+      
+      return project
+    else
+      puts "❌ Project '#{project_name}' not found in global config"
+      puts "Available projects:"
+      global_config['projects'].each do |p|
+        puts "  - #{p['name'] || 'unnamed'} (#{p['path']})"
+      end
+      puts "\nCheck your global config at #{GLOBAL_CONFIG_PATH}"
+      exit 1
+    end
   end
 
   def determine_command(config)


### PR DESCRIPTION
Instead of going to the project directory and running dev-serve, now you can also run the server from anywhere by providing project name as an argument.
For this to work the configuration for the project needs to be added to the global config file with the newly introduced name option for the project.